### PR TITLE
Fix SBCL warnings

### DIFF
--- a/input.lisp
+++ b/input.lisp
@@ -42,6 +42,7 @@
 CHUNKED-INPUT-STREAM."
   nil)
 
+(defgeneric (setf chunked-stream-input-chunking-p) (new-value stream))
 (defmethod (setf chunked-stream-input-chunking-p) (new-value (stream chunked-input-stream))
   "Switches input chunking for STREAM on or off."
   (unless (eq (not new-value) (not (chunked-stream-input-chunking-p stream)))
@@ -69,6 +70,7 @@ CHUNKED-INPUT-STREAM."
   (clear-input (chunked-stream-stream stream))
   nil)
 
+(defgeneric chunked-input-available-p (stream))
 (defmethod chunked-input-available-p ((stream chunked-input-stream))
   "Whether there's unread input waiting in the chunk buffer."
   (< (chunked-stream-input-index stream)
@@ -82,6 +84,7 @@ something in the buffer.  Otherwise we poll the underlying stream."
              (fill-buffer stream)))
         (t (listen (chunked-stream-stream stream)))))
 
+(defgeneric fill-buffer (stream))
 (defmethod fill-buffer ((stream chunked-input-stream))
   "Re-fills the chunk buffer.  Returns NIL if chunking has ended."
   (let ((inner-stream (chunked-stream-stream stream))

--- a/output.lisp
+++ b/output.lisp
@@ -34,6 +34,7 @@
 CHUNKED-OUTPUT-STREAM."
   nil)
 
+(defgeneric write-chunk (stream sequence &key start end))
 (defmethod write-chunk ((stream chunked-output-stream) sequence
                         &key (start 0)
                              (end (length sequence)))
@@ -48,6 +49,7 @@ underlying stream of STREAM as one chunk."
     (write-sequence sequence output-stream :start start :end end)
     (write-sequence +crlf+ output-stream)))
 
+(defgeneric flush-buffer (stream))
 (defmethod flush-buffer ((stream chunked-output-stream))
   "Uses WRITE-CHUNK to empty the output buffer unless it is
 already empty."
@@ -57,6 +59,7 @@ already empty."
       (write-chunk stream output-buffer :end output-index)
       (setq output-index 0))))
 
+(defgeneric (setf chunked-stream-output-chunking-p) (new-value streams))
 (defmethod (setf chunked-stream-output-chunking-p) (new-value (stream chunked-output-stream))
   "Switches output chunking for STREAM on or off."
   (unless (eq (not new-value) (not (chunked-stream-output-chunking-p stream)))

--- a/packages.lisp
+++ b/packages.lisp
@@ -33,6 +33,7 @@
   (:use :cl :trivial-gray-streams)
   #+:lispworks
   (:import-from :lw :when-let)
+  (:shadow :open-stream-p :close)
   (:export :*accept-bogus-eols*
            :*current-error-message*
            :*treat-semicolon-as-continuation*

--- a/read.lisp
+++ b/read.lisp
@@ -126,7 +126,7 @@ where spaces and tab characters are trimmed from the start and the
 end.  Might return STRING."
   ;; optimized version to replace STRING-TRIM, suggested by Jason Kantz
   (declare (optimize
-            speed
+	    #-:sbcl speed
             (space 0)
             (debug 1)
             (compilation-speed 0)

--- a/streams.lisp
+++ b/streams.lisp
@@ -98,10 +98,12 @@ a CHUNKED-INPUT-STREAM as well as a CHUNKED-OUTPUT-STREAM."))
 flexi streams if you need a character stream."
   '(unsigned-byte 8))
 
+(defgeneric open-stream-p (stream))
 (defmethod open-stream-p ((stream chunked-stream))
   "A chunked stream is open if its underlying stream is open."
   (open-stream-p (chunked-stream-stream stream)))
 
+(defgeneric close (stream &key abort))
 (defmethod close ((stream chunked-stream) &key abort)
   "If a chunked stream is closed, we close the underlying stream as well."
   (with-slots (real-stream)
@@ -129,3 +131,4 @@ binary stream."
                        ((output-stream-p stream)
                         'chunked-output-stream))
                  :real-stream stream))
+


### PR DESCRIPTION
When loading Chunga under SBCL 1.3.15 compile warnings are emitted. This fix seeks to eliminate them.