### PR TITLE
Only run editor:setup-indent if :lw-editor is present

### DIFF
--- a/specials.lisp
+++ b/specials.lisp
@@ -35,7 +35,7 @@
   `(defconstant ,name (if (boundp ',name) (symbol-value ',name) ,value)
      ,@(when doc (list doc))))
 
-#+:lispworks
+#+(and :lispworks :lw-editor)
 (editor:setup-indent "define-constant" 1 2 4)
 
 (defconstant +output-buffer-size+ 8192


### PR DESCRIPTION
In particular, when using Lispworks for Android (and probably iOS), the EDITOR package is unavailable.