### PR TITLE
adding as-keyword-if-found to avoid potential memory leak 

### DIFF
--- a/known-words.lisp
+++ b/known-words.lisp
@@ -135,6 +135,11 @@ but includes WebDAV stuff and other things as well."))
   "A hash table which maps keywords derived from +KNOWN-WORDS+ to
 capitalized strings.")
 
+(defun as-keyword-if-found (string &key (destructivep t))
+  "Checks if the string STRING is found as a keyword and if it is, returns the keyword, otherwise it returns the input string."
+  (or (find-symbol (string-upcase string) (find-package "KEYWORD"))
+      string))
+
 (defun as-keyword (string &key (destructivep t))
   "Converts the string STRING to a keyword where all characters are
 uppercase or lowercase, taking into account the current readtable

--- a/packages.lisp
+++ b/packages.lisp
@@ -37,6 +37,7 @@
            :*current-error-message*
            :*treat-semicolon-as-continuation*
            :assert-char
+           :as-keyword-if-found
            :as-keyword
            :as-capitalized-string
            :chunga-error

--- a/read.lisp
+++ b/read.lisp
@@ -160,16 +160,16 @@ logs the header lines to LOG-STREAM if it is not NIL."
                "Reads one header line, considering continuations."
                (with-output-to-string (header-line)
                  (loop
-                  (let ((line (trim-whitespace (read-line* stream log-stream))))
-                    (when (zerop (length line))
-                      (return))
-                    (write-sequence line header-line)
-                    (let ((next (peek-char* stream)))
-                      (unless (whitespacep next)
-                        (return)))
-                    ;; we've seen whitespace starting a continutation,
-                    ;; so we loop
-                    (write-char #\Space header-line)))))
+                   (let ((line (trim-whitespace (read-line* stream log-stream))))
+                     (when (zerop (length line))
+                       (return))
+                     (write-sequence line header-line)
+                     (let ((next (peek-char* stream)))
+                       (unless (whitespacep next)
+                         (return)))
+                     ;; we've seen whitespace starting a continutation,
+                     ;; so we loop
+                     (write-char #\Space header-line)))))
              (split-header (line)
                "Splits line at colon and converts it into a cons.
 Returns NIL if LINE consists solely of whitespace."
@@ -179,7 +179,7 @@ Returns NIL if LINE consists solely of whitespace."
                                              :stream stream
                                              :format-control "Couldn't find colon in header line ~S."
                                              :format-arguments (list line)))))
-                   (cons (as-keyword (subseq line 0 colon-pos))
+                   (cons (as-keyword-if-found (subseq line 0 colon-pos))
                          (trim-whitespace (subseq line (1+ colon-pos)))))))
              (add-header (pair)
                "Adds the name/value cons PAIR to HEADERS.  Takes


### PR DESCRIPTION
adding as-keyword-if-found to avoid potential memory leak of adding any headers provided by a client to the keyword package. See https://github.com/edicl/hunchentoot/issues/24 and https://github.com/edicl/hunchentoot/pull/234