### PR TITLE
Fix #'AS-KEYWORD-IF-FOUND

### DIFF
--- a/known-words.lisp
+++ b/known-words.lisp
@@ -249,9 +249,14 @@ but includes WebDAV stuff and other things as well."))
 capitalized strings.")
 
 (defun as-keyword-if-found (string &key (destructivep t))
-  "Checks if the string STRING is found as a keyword and if it is, returns the keyword, otherwise it returns the input string."
-  (or (find-symbol (string-upcase string) (find-package "KEYWORD"))
-      string))
+  "Checks if the string STRING is found as a keyword where all character cases
+are according to the current readtable case; might destructively modify STRING
+if DESTRUCTIVEP is true, which is the default. If there is no interned keyword
+then the case-normalised string is returned."
+  (let ((name (case-normalize-string string destructivep)))
+    (or (gethash string +string-to-keyword-hash+)
+        (find-symbol name (find-package "KEYWORD"))
+        name)))
 
 (defun as-keyword (string &key (destructivep t))
   "Converts the string STRING to a keyword where all characters are

--- a/packages.lisp
+++ b/packages.lisp
@@ -40,6 +40,7 @@
            :as-keyword-if-found
            :as-keyword
            :as-capitalized-string
+           :case-normalize-string
            :chunga-error
            :chunga-warning
            :chunked-input-stream
@@ -69,4 +70,4 @@
            :with-character-stream-semantics
            :chunked-input-stream-eof-after-last-chunk
            :chunked-input-stream-length))
-           
+

--- a/util.lisp
+++ b/util.lisp
@@ -43,20 +43,22 @@ SUFFIX.  Individual elements are compared with TEST."
     (or (null mismatch)
         (= mismatch (- (length seq) (length suffix))))))
 
+(defun case-normalize-string (string destructivep)
+  "Converts the string STRING to a string where all characters are
+uppercase or lowercase, taking into account the current readtable
+case.  Destructively modifies STRING if DESTRUCTIVEP is true."
+  (funcall (if destructivep
+               (if (eq (readtable-case *readtable*) :upcase)
+                   #'nstring-upcase #'nstring-downcase)
+               (if (eq (readtable-case *readtable*) :upcase)
+                   #'string-upcase #'string-downcase))
+           string))
+
 (defun make-keyword (string destructivep)
   "Converts the string STRING to a keyword where all characters are
 uppercase or lowercase, taking into account the current readtable
 case.  Destructively modifies STRING if DESTRUCTIVEP is true."
-  (intern (funcall
-           (if destructivep
-             (if (eq (readtable-case *readtable*) :upcase)
-               #'nstring-upcase
-               #'nstring-downcase)
-             (if (eq (readtable-case *readtable*) :upcase)
-               #'string-upcase
-               #'string-downcase))
-           string)
-          :keyword))
+  (intern (case-normalize-string string destructivep) :keyword))
 
 (defun read-char* (stream &optional (eof-error-p t) eof-value)
   "The streams we're dealing with are all binary with element type


### PR DESCRIPTION
This function now behaves similarly to `make-keyword`: respecting readtable case and the `destructivep` argument, first checking the cache of known words, then the package, and finally returning the possibly-modified string rather than making a new symbol.